### PR TITLE
Micro-Benchmarks and Bug-Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ COMMON_FILES := common.o data/hash.o data/list.o data/stack.o
 SERVER_FILES := rmem_table.o $(COMMON_FILES)
 CLIENT_FILES := rvm.o rmem.o buddy_malloc.o $(COMMON_FILES)
 APPS    := rmem-server rmem-test
-TESTS   := tests/rvm_test_normal tests/rvm_test_txn_commit tests/rvm_test_recovery tests/rvm_test_free tests/rvm_test_big_commit tests/rvm_test_size_alloc
+TESTS   := tests/rvm_test_normal tests/rvm_test_txn_commit tests/rvm_test_recovery tests/rvm_test_free tests/rvm_test_big_commit tests/rvm_test_size_alloc tests/rvm_test_full
 HEADERS := $(wildcard *.h)
 
 STATIC_LIB = librvm.a

--- a/common.c
+++ b/common.c
@@ -133,6 +133,12 @@ void event_loop(struct rdma_event_channel *ec, int exit_on_disconnect)
     }
 }
 
+void dump_wc(struct ibv_wc *wc)
+{
+    fprintf(stderr, "status: %d\n", wc->status);
+    fprintf(stderr, "opcode: %d\n", wc->opcode);
+}
+
 void * poll_cq(void *ctx)
 {
     struct ibv_cq *cq;
@@ -146,8 +152,10 @@ void * poll_cq(void *ctx)
         while (ibv_poll_cq(cq, 1, &wc)) {
             if (wc.status == IBV_WC_SUCCESS)
                 s_on_completion_cb(&wc);
-            else
+            else {
+		dump_wc(&wc);
                 rc_die("poll_cq: status is not IBV_WC_SUCCESS");
+	    }
         }
     }
 

--- a/evaluation/ubenchmarks/.gitignore
+++ b/evaluation/ubenchmarks/.gitignore
@@ -1,0 +1,1 @@
+/commit-bm

--- a/evaluation/ubenchmarks/.gitignore
+++ b/evaluation/ubenchmarks/.gitignore
@@ -1,1 +1,2 @@
 /commit-bm
+/recovery-bm

--- a/evaluation/ubenchmarks/Makefile
+++ b/evaluation/ubenchmarks/Makefile
@@ -4,9 +4,14 @@ LIBS := -lrvm -lrdmacm -libverbs -lpthread
 LDFLAGS := -L../.. -std=gnu11 $(LIBS)
 LD := gcc
 
-BENCHMARKS := commit-bm
+BENCHMARKS := commit-bm recovery-bm
+
+all: $(BENCHMARKS)
 
 commit-bm: commit-bm.o
+	$(LD) $^ -o $@ $(LDFLAGS)
+
+recovery-bm: recovery-bm.o
 	$(LD) $^ -o $@ $(LDFLAGS)
 
 clean:

--- a/evaluation/ubenchmarks/Makefile
+++ b/evaluation/ubenchmarks/Makefile
@@ -1,5 +1,5 @@
 INCLUDES := -I../..
-CFLAGS  := $(INCLUDES) -Wall -O3 -std=gnu11
+CFLAGS  := $(INCLUDES) -Wall -g -std=gnu11
 LIBS := -lrvm -lrdmacm -libverbs -lpthread
 LDFLAGS := -L../.. -std=gnu11 $(LIBS)
 LD := gcc

--- a/evaluation/ubenchmarks/Makefile
+++ b/evaluation/ubenchmarks/Makefile
@@ -1,0 +1,13 @@
+INCLUDES := -I../..
+CFLAGS  := $(INCLUDES) -Wall -O3 -std=gnu11
+LIBS := -lrvm -lrdmacm -libverbs -lpthread
+LDFLAGS := -L../.. -std=gnu11 $(LIBS)
+LD := gcc
+
+BENCHMARKS := commit-bm
+
+commit-bm: commit-bm.o
+	$(LD) $^ -o $@ $(LDFLAGS)
+
+clean:
+	rm -f $(BENCHMARKS) *.o

--- a/evaluation/ubenchmarks/commit-bm.c
+++ b/evaluation/ubenchmarks/commit-bm.c
@@ -99,6 +99,20 @@ double rvm_test(int **pages, int npages, char *host, char *port)
 
     endtime = gettime();
 
+    txid = rvm_txn_begin(rvm);
+    if (txid < 0) {
+	perror("rvm_txn_begin");
+	exit(EXIT_FAILURE);
+    }
+
+    for (int i = 0; i < npages; i++)
+	rvm_free(rvm, pages[i]);
+
+    if (!rvm_txn_commit(rvm, txid)) {
+	perror("rvm_txn_commit");
+	exit(EXIT_FAILURE);
+    }
+
     rvm_cfg_destroy(rvm);
 
     return endtime - starttime;

--- a/evaluation/ubenchmarks/commit-bm.c
+++ b/evaluation/ubenchmarks/commit-bm.c
@@ -99,20 +99,6 @@ double rvm_test(int **pages, int npages, char *host, char *port)
 
     endtime = gettime();
 
-    txid = rvm_txn_begin(rvm);
-    if (txid < 0) {
-	perror("rvm_txn_begin");
-	exit(EXIT_FAILURE);
-    }
-
-    for (int i = 0; i < npages; i++)
-	rvm_free(rvm, pages[i]);
-
-    if (!rvm_txn_commit(rvm, txid)) {
-	perror("rvm_txn_commit");
-	exit(EXIT_FAILURE);
-    }
-
     rvm_cfg_destroy(rvm);
 
     return endtime - starttime;

--- a/evaluation/ubenchmarks/commit-bm.c
+++ b/evaluation/ubenchmarks/commit-bm.c
@@ -1,35 +1,14 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 #include <sys/mman.h>
 
 #include <rvm.h>
 #include <rmem.h>
 
-#define PAGE_SIZE sysconf(_SC_PAGESIZE)
+#include "util.h"
+
 #define ITERATIONS 1000
-#define NS_PER_SEC (1000.0 * 1000.0 * 1000.0)
-
-static inline double gettime(void)
-{
-    struct timespec ts;
-
-    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
-	perror("clock_gettime");
-	exit(EXIT_FAILURE);
-    }
-
-    return ts.tv_sec + ((double) ts.tv_nsec) / NS_PER_SEC;
-}
-
-static inline void touch_page(int *page)
-{
-    int page_len = PAGE_SIZE / sizeof(int);
-
-    for (int i = 0; i < page_len; i++)
-	page[i] = random();
-}
 
 /* A test without RVM as the baseline */
 double norvm_test(int **pages, int npages)

--- a/evaluation/ubenchmarks/commit-bm.c
+++ b/evaluation/ubenchmarks/commit-bm.c
@@ -1,0 +1,139 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
+#include <rvm.h>
+#include <rmem.h>
+
+#define PAGE_SIZE sysconf(_SC_PAGESIZE)
+#define ITERATIONS 1000
+#define NS_PER_SEC (1000.0 * 1000.0 * 1000.0)
+
+static inline double gettime(void)
+{
+    struct timespec ts;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+	perror("clock_gettime");
+	exit(EXIT_FAILURE);
+    }
+
+    return ts.tv_sec + ((double) ts.tv_nsec) / NS_PER_SEC;
+}
+
+static inline void touch_page(int *page)
+{
+    int page_len = PAGE_SIZE / sizeof(int);
+
+    for (int i = 0; i < page_len; i++)
+	page[i] = random();
+}
+
+/* A test without RVM as the baseline */
+double norvm_test(int **pages, int npages)
+{
+    double starttime, endtime;
+
+    for (int i = 0; i < npages; i++) {
+	pages[i] = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+		MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	if (pages[i] == MAP_FAILED) {
+	    perror("mmap");
+	    exit(EXIT_FAILURE);
+	}
+    }
+
+    starttime = gettime();
+
+    for (int j = 0; j < ITERATIONS; j++) {
+	for (int i = 0; i < npages; i++)
+	    touch_page(pages[i]);
+    }
+
+    endtime = gettime();
+
+    for (int i = 0; i < npages; i++) {
+	munmap(pages[i], PAGE_SIZE);
+    }
+
+    return endtime - starttime;
+}
+
+/* A test with RVM */
+double rvm_test(int **pages, int npages, char *host, char *port)
+{
+    double starttime, endtime;
+
+    rvm_cfg_t *rvm;
+    rvm_opt_t opt;
+    rvm_txid_t txid;
+
+    opt.host = host;
+    opt.port = port;
+    opt.recovery = false;
+
+    rvm = rvm_cfg_create(&opt, create_rmem_layer);
+    if (rvm == NULL) {
+	perror("rvm_cfg_create");
+	exit(EXIT_FAILURE);
+    }
+
+    for (int i = 0; i < npages; i++) {
+	pages[i] = rvm_alloc(rvm, PAGE_SIZE);
+	if (pages[i] == NULL) {
+	    perror("rvm_alloc");
+	    exit(EXIT_FAILURE);
+	}
+    }
+
+    starttime = gettime();
+
+    for (int j = 0; j < ITERATIONS; j++) {
+	txid = rvm_txn_begin(rvm);
+	if (txid < 0) {
+	    perror("rvm_txn_begin");
+	    exit(EXIT_FAILURE);
+	}
+	for (int i = 0; i < npages; i++)
+	    touch_page(pages[i]);
+	if (!rvm_txn_commit(rvm, txid)) {
+	    perror("rvm_txn_commit");
+	    exit(EXIT_FAILURE);
+	}
+    }
+
+    endtime = gettime();
+
+    for (int i = 0; i < npages; i++)
+	rvm_free(rvm, pages[i]);
+
+    rvm_cfg_destroy(rvm);
+
+    return endtime - starttime;
+}
+
+int main(int argc, char *argv[])
+{
+    int **pages, npages;
+    double t1, t2, txn_time;
+
+    if (argc < 4) {
+	fprintf(stderr, "Usage: %s <host> <port> <npages>\n", argv[0]);
+	return -1;
+    }
+
+    npages = atoi(argv[3]);
+    pages = calloc(npages, sizeof(*pages));
+
+    t1 = norvm_test(pages, npages);
+    t2 = rvm_test(pages, npages, argv[1], argv[2]);
+    txn_time = (t2 - t1) / ITERATIONS;
+
+    printf("Avg. commit time %f seconds\n", txn_time);
+
+    free(pages);
+
+    return 0;
+}

--- a/evaluation/ubenchmarks/recovery-bm.c
+++ b/evaluation/ubenchmarks/recovery-bm.c
@@ -1,0 +1,98 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <rvm.h>
+#include <rmem.h>
+
+#include "util.h"
+
+void setup_pages(char *host, char *port, int **pages, int npages)
+{
+    rvm_cfg_t *rvm;
+    rvm_opt_t opt;
+
+    opt.host = host;
+    opt.port = port;
+    opt.recovery = false;
+
+    rvm = rvm_cfg_create(&opt, create_rmem_layer);
+    if (rvm == NULL) {
+	perror("rvm_cfg_create");
+	exit(EXIT_FAILURE);
+    }
+
+    for (int i = 0; i < npages; i++) {
+	pages[i] = rvm_alloc(rvm, PAGE_SIZE);
+	if (pages[i] == NULL) {
+	    perror("rvm_alloc");
+	    exit(EXIT_FAILURE);
+	}
+    }
+
+    rvm_cfg_destroy(rvm);
+}
+
+void recover_pages(char *host, char *port,
+	int **pages, int npages, bool free_at_end)
+{
+    rvm_cfg_t *rvm;
+    rvm_opt_t opt;
+
+    opt.host = host;
+    opt.port = port;
+    opt.recovery = true;
+
+    rvm = rvm_cfg_create(&opt, create_rmem_layer);
+    if (rvm == NULL) {
+	perror("rvm_cfg_create");
+	exit(EXIT_FAILURE);
+    }
+
+    for (int i = 0; i < npages; i++) {
+	pages[i] = rvm_rec(rvm);
+	if (pages[i] == NULL) {
+	    perror("rvm_rec");
+	    exit(EXIT_FAILURE);
+	}
+    }
+
+    if (free_at_end) {
+	for (int i = 0; i < npages; i++)
+	    rvm_free(rvm, pages[i]);
+    }
+
+    rvm_cfg_destroy(rvm);
+}
+
+int main(int argc, char *argv[])
+{
+    int **pages, npages;
+    double starttime, alloctime, rectime;
+    char *host, *port;
+
+    if (argc < 4) {
+	fprintf(stderr, "%s <host> <port> <npages>\n", argv[0]);
+	return -1;
+    }
+
+    host = argv[1];
+    port = argv[2];
+    npages = atoi(argv[3]);
+    pages = calloc(npages, sizeof(*pages));
+
+    starttime = gettime();
+    setup_pages(host, port, pages, npages);
+    alloctime = gettime() - starttime;
+
+    starttime = gettime();
+    recover_pages(host, port, pages, npages, false);
+    rectime = gettime() - starttime;
+
+    recover_pages(host, port, pages, npages, true);
+
+    free(pages);
+
+    printf("alloc time %f, recovery time %f\n", alloctime, rectime);
+
+    return 0;
+}

--- a/evaluation/ubenchmarks/recovery-bm.c
+++ b/evaluation/ubenchmarks/recovery-bm.c
@@ -37,16 +37,13 @@ void setup_pages(char *host, char *port, int **pages, int npages)
 	    perror("rvm_alloc");
 	    exit(EXIT_FAILURE);
 	}
+	touch_page(pages[i]);
     }
-
-    printf("Committing allocations.\n");
 
     if (!rvm_txn_commit(rvm, txid)) {
 	perror("rvm_txn_commit");
 	exit(EXIT_FAILURE);
     }
-
-    printf("Commit successful\n");
 
     rvm_cfg_destroy(rvm);
 }
@@ -75,11 +72,11 @@ void recover_pages(char *host, char *port,
 int main(int argc, char *argv[])
 {
     int **pages, npages;
-    double starttime, alloctime, rectime;
+    double starttime, endtime;
     char *host, *port;
 
-    if (argc < 4) {
-	fprintf(stderr, "%s <host> <port> <npages>\n", argv[0]);
+    if (argc < 5) {
+	fprintf(stderr, "%s <host> <port> <npages> <recovery>\n", argv[0]);
 	return -1;
     }
 
@@ -88,16 +85,15 @@ int main(int argc, char *argv[])
     npages = atoi(argv[3]);
     pages = calloc(npages, sizeof(*pages));
 
-    starttime = gettime();
-    setup_pages(host, port, pages, npages);
-    alloctime = gettime() - starttime;
-
-    starttime = gettime();
-    recover_pages(host, port, pages, npages);
-    rectime = gettime() - starttime;
-    free(pages);
-
-    printf("alloc time %f, recovery time %f\n", alloctime, rectime);
+    if (argv[4][0] == 'y') {
+	starttime = gettime();
+	recover_pages(host, port, pages, npages);
+	endtime = gettime();
+	free(pages);
+	printf("recovery time %f\n", endtime - starttime);
+    } else {
+	setup_pages(host, port, pages, npages);
+    }
 
     return 0;
 }

--- a/evaluation/ubenchmarks/recovery-bm.c
+++ b/evaluation/ubenchmarks/recovery-bm.c
@@ -69,9 +69,6 @@ void recover_pages(char *host, char *port,
 	exit(EXIT_FAILURE);
     }
 
-    for (int i = 0; i < npages; i++)
-	rvm_free(rvm, pages[i]);
-
     rvm_cfg_destroy(rvm);
 }
 

--- a/evaluation/ubenchmarks/util.h
+++ b/evaluation/ubenchmarks/util.h
@@ -1,0 +1,29 @@
+#ifndef __UBM_UTIL_H__
+#define __UBM_UTIL_H__
+
+#include <unistd.h>
+
+#define PAGE_SIZE sysconf(_SC_PAGESIZE)
+#define NS_PER_SEC (1000.0 * 1000.0 * 1000.0)
+
+static inline double gettime(void)
+{
+    struct timespec ts;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+	perror("clock_gettime");
+	exit(EXIT_FAILURE);
+    }
+
+    return ts.tv_sec + ((double) ts.tv_nsec) / NS_PER_SEC;
+}
+
+static inline void touch_page(int *page)
+{
+    int page_len = PAGE_SIZE / sizeof(int);
+
+    for (int i = 0; i < page_len; i++)
+	page[i] = random();
+}
+
+#endif

--- a/messages.h
+++ b/messages.h
@@ -12,12 +12,12 @@ enum message_id {
     MSG_MR,
     MSG_ALLOC,
     MSG_LOOKUP,
-    MSG_FREE,
     MSG_MEMRESP,
-    MSG_CP_REQ,
-    MSG_CP_GO,
-    MSG_CP_ABORT,
-    MSG_CP_ACK,
+    MSG_TXN_FREE,
+    MSG_TXN_CP,
+    MSG_TXN_GO,
+    MSG_TXN_ABORT,
+    MSG_TXN_ACK,
     MSG_TAG_ADDR_MAP,
     MSG_STARTUP_ACK
 };
@@ -53,7 +53,7 @@ struct message {
 	    uint64_t dst;
 	    uint64_t src;
 	    uint64_t size;
-	} cpreq;
+	} cp;
 	struct {
             int size;
 	    tag_addr_entry_t data[TAG_ADDR_MAP_SIZE_MSG];

--- a/messages.h
+++ b/messages.h
@@ -19,7 +19,7 @@ enum message_id {
     MSG_CP_ABORT,
     MSG_CP_ACK,
     MSG_TAG_ADDR_MAP,
-    MSG_TAG_ADDR_MAP_ACK
+    MSG_STARTUP_ACK
 };
 
 typedef struct tag_addr_entry {

--- a/rmem-server.c
+++ b/rmem-server.c
@@ -217,7 +217,7 @@ static void on_completion(struct ibv_wc *wc)
         switch (msg->id) {
             case MSG_ALLOC:
                 TEST_NZ(pthread_mutex_lock(&alloc_mutex));
-                ptr = rmem_alloc(&rmem, msg->data.alloc.size,
+                ptr = rmem_table_alloc(&rmem, msg->data.alloc.size,
                         msg->data.alloc.tag);
                 TEST_NZ(pthread_mutex_unlock(&alloc_mutex));
                 ctx->send_msg->id = MSG_MEMRESP;

--- a/rmem-server.c
+++ b/rmem-server.c
@@ -194,8 +194,8 @@ static void on_connection(struct rdma_cm_id *id)
                 (uintptr_t)rmem.mem));
 
     send_message(id);
-
-    sleep(1);
+    post_msg_receive(id);
+    TEST_NZ(sem_init(&ctx->ack_sem, 0, 0));
 
     send_tag_to_addr_info(id);
 
@@ -272,7 +272,7 @@ static void on_completion(struct ibv_wc *wc)
                 ctx->send_msg->id = MSG_CP_ACK;
                 send_message(id);
                 break;
-	    case MSG_TAG_ADDR_MAP_ACK:
+	    case MSG_STARTUP_ACK:
 		TEST_NZ(sem_post(&ctx->ack_sem));
 		break;
             default:

--- a/rmem-test.c
+++ b/rmem-test.c
@@ -12,23 +12,23 @@ int main(void)
 
     init_rmem_table(&rmem);
 
-    data1 = rmem_alloc(&rmem, 100, 1);
-    data2 = rmem_alloc(&rmem, 50, 2);
-    data3 = rmem_alloc(&rmem, 120, 3);
+    data1 = rmem_table_alloc(&rmem, 100, 1);
+    data2 = rmem_table_alloc(&rmem, 50, 2);
+    data3 = rmem_table_alloc(&rmem, 120, 3);
 
     memset(data1, '1', 100);
     memset(data2, '2', 50);
     memset(data3, '3', 120);
 
     rmem_table_free(&rmem, data2);
-    data2 = rmem_alloc(&rmem, 70, 2);
+    data2 = rmem_table_alloc(&rmem, 70, 2);
     memset(data2, '2', 70);
 
-    data4 = rmem_alloc(&rmem, 25, 4);
+    data4 = rmem_table_alloc(&rmem, 25, 4);
     memset(data4, '4', 25);
 
     rmem_table_free(&rmem, data3);
-    data3 = rmem_alloc(&rmem, 120, 3);
+    data3 = rmem_table_alloc(&rmem, 120, 3);
     memset(data3, '3', 120);
 
     assert(data1 == rmem_table_lookup(&rmem, 1));

--- a/rmem.c
+++ b/rmem.c
@@ -135,10 +135,10 @@ int rmem_multi_cp_go(struct rmem *rmem)
 
     if (send_message(rmem->id))
 	return -1;
-    if (sem_wait(&ctx->send_sem))
+    if (post_receive(rmem->id))
 	return -1;
 
-    if (post_receive(rmem->id))
+    if (sem_wait(&ctx->send_sem))
 	return -1;
     if (sem_wait(&ctx->recv_sem))
 	return -1;

--- a/rmem.c
+++ b/rmem.c
@@ -196,7 +196,7 @@ void insert_tag_to_addr(struct rmem* rmem, uint32_t tag, uintptr_t addr) {
 static
 void receive_tag_to_addr_info(struct rmem* rmem) 
 {
-    rmem->ctx.send_msg->id = MSG_TAG_ADDR_MAP_ACK;
+    rmem->ctx.send_msg->id = MSG_STARTUP_ACK;
 
     while (1) {
         TEST_NZ(post_receive(rmem->id));

--- a/rmem.c
+++ b/rmem.c
@@ -203,6 +203,7 @@ void receive_tag_to_addr_info(struct rmem* rmem)
         sem_wait(&rmem->ctx.recv_sem);
 
         int size = rmem->ctx.recv_msg->data.tag_addr_map.size;
+	printf("Received %d mappings\n", size);
 
         tag_addr_entry_t* entries = 
             (tag_addr_entry_t*)rmem->ctx.recv_msg->data.tag_addr_map.data;
@@ -213,6 +214,7 @@ void receive_tag_to_addr_info(struct rmem* rmem)
         }
 
 	TEST_NZ(send_message(rmem->id));
+	sem_wait(&rmem->ctx.send_sem);
 
         if (size < TAG_ADDR_MAP_SIZE_MSG)
             break;
@@ -270,6 +272,11 @@ void rmem_connect(rmem_layer_t *rmem_layer, const char *host, const char *port)
     sem_wait(&rmem->ctx.recv_sem);
     rmem->ctx.peer_addr = rmem->ctx.recv_msg->data.mr.addr;
     rmem->ctx.peer_rkey = rmem->ctx.recv_msg->data.mr.rkey;
+
+    // acknowledge that we received the MR
+    rmem->ctx.send_msg->id = MSG_STARTUP_ACK;
+    TEST_NZ(send_message(rmem->id));
+    sem_wait(&rmem->ctx.send_sem);
 
     receive_tag_to_addr_info(rmem);
 }
@@ -434,6 +441,8 @@ int rmem_free(rmem_layer_t *rmem_layer, uint32_t tag)
     uintptr_t addr = lookup_remote_addr(rmem->tag_to_addr, tag);
     CHECK_ERROR(addr == 0,
             ("Failure: tag not found in tag_to_addr\n"));
+
+    LOG(8, ("rmem_free addr: %ld tag: %d\n", addr, tag));
 
     hash_delete_item(rmem->tag_to_addr, tag);
 

--- a/rmem_table.c
+++ b/rmem_table.c
@@ -206,7 +206,7 @@ static struct alloc_entry *find_entry(struct rmem_table *rmem, tag_t tag)
     return NULL;
 }
 
-void *rmem_alloc(struct rmem_table *rmem, size_t size, tag_t tag)
+void *rmem_table_alloc(struct rmem_table *rmem, size_t size, tag_t tag)
 {
     size_t req_size = size + DATA_OFFSET;
     struct alloc_entry *entry = NULL;
@@ -220,7 +220,7 @@ void *rmem_alloc(struct rmem_table *rmem, size_t size, tag_t tag)
     entry = find_entry(rmem, tag);
     if (entry != NULL) {
         LOG(5, ("Requested tag is not unique\n"));
-    	return entry->start;
+    	return entry->start + DATA_OFFSET;
     }
 
     free_node = rmem->free_list.next;

--- a/rmem_table.c
+++ b/rmem_table.c
@@ -29,11 +29,11 @@ static inline struct alloc_entry *entry_of_htable(struct list_head *list)
     return (struct alloc_entry *) (((void *) list) - offset);
 }
 
-static inline struct rmem_cp_info *cp_info_of_list(struct list_head *list)
+static inline struct rmem_txn *txn_of_list(struct list_head *list)
 {
-    struct rmem_cp_info info;
-    int offset = ((void *) &info.list) - ((void *) &info);
-    return (struct rmem_cp_info *) (((void *) list) - offset);
+    struct rmem_txn txn;
+    int offset = ((void *) &txn.list) - ((void *) &txn);
+    return (struct rmem_txn *) (((void *) list) - offset);
 }
 
 static inline void list_init(struct list_head *node)
@@ -345,6 +345,11 @@ void rmem_table_free(struct rmem_table *rmem, void *ptr)
 
     memcpy(&entry, start, sizeof(struct alloc_entry *));
 
+    if (entry->free) {
+	fprintf(stderr, "This block has already been freed.\n");
+	abort();
+    }
+
     entry->free = 1;
     entry->tag = 0;
     //dump_free_list(rmem);
@@ -386,48 +391,95 @@ void dump_rmem_table(struct rmem_table *rmem)
     //dump_free_list(rmem);
 }
 
-void cp_info_list_init(struct rmem_cp_info_list *list)
+void txn_list_init(struct rmem_txn_list *list)
 {
     list_init(&list->head);
 }
 
-void cp_info_list_clear(struct rmem_cp_info_list *list)
+void txn_list_clear(struct rmem_txn_list *list)
 {
-    struct rmem_cp_info *info;
+    struct rmem_txn *txn;
 
     while (!list_empty(&list->head)) {
-	info = cp_info_of_list(list->head.next);
+	txn = txn_of_list(list->head.next);
 	list_delete(list->head.next);
-	free(info);
+	free(txn);
     }
 }
 
-int cp_info_list_add(struct rmem_cp_info_list *list,
+int txn_list_add_cp(struct rmem_txn_list *list,
 	void *dst, void *src, size_t size)
 {
-    struct rmem_cp_info *info;
+    struct rmem_txn *txn;
 
-    info = malloc(sizeof(struct rmem_cp_info));
-    if (info == NULL)
+    txn = malloc(sizeof(struct rmem_txn));
+    if (txn == NULL)
 	return -1;
 
-    info->src = src;
-    info->dst = dst;
-    info->size = size;
+    txn->type = TXN_CP;
+    txn->src = src;
+    txn->dst = dst;
+    txn->size = size;
 
-    list_append(&list->head, &info->list);
+    list_append(&list->head, &txn->list);
 
     return 0;
 }
 
-void multi_cp(struct rmem_cp_info_list *list)
+/*int txn_list_add_alloc(struct rmem_txn_list *list, size_t size)
 {
-    struct rmem_cp_info *info;
+    struct rmem_txn *txn;
+
+    txn = malloc(sizeof(struct rmem_txn));
+    if (txn == NULL)
+	return -1;
+
+    txn->type = TXN_ALLOC;
+    txn->src = 0;
+    txn->dst = 0;
+    txn->size = size;
+
+    list_append(&list->head, &txn->list);
+
+    return 0;
+}*/
+
+int txn_list_add_free(struct rmem_txn_list *list, void *addr)
+{
+    struct rmem_txn *txn;
+
+    txn = malloc(sizeof(struct rmem_txn));
+    if (txn == NULL)
+	return -1;
+
+    txn->type = TXN_FREE;
+    txn->src = addr;
+    txn->dst = 0;
+    txn->size = 0;
+
+    list_append(&list->head, &txn->list);
+
+    return 0;
+}
+
+void txn_commit(struct rmem_table *rmem, struct rmem_txn_list *list)
+{
+    struct rmem_txn *txn;
     struct list_head *node = list->head.next;
 
     while (node != &list->head) {
-        info = cp_info_of_list(node);
-        memcpy(info->dst, info->src, info->size);
+        txn = txn_of_list(node);
+	switch (txn->type) {
+	case TXN_CP:
+	    memcpy(txn->dst, txn->src, txn->size);
+	    break;
+	case TXN_FREE:
+	    rmem_table_free(rmem, txn->src);
+	    break;
+	default:
+	    fprintf(stderr, "Unknown TXN type\n");
+	    abort();
+	}
         node = node->next;
     }
 }

--- a/rmem_table.h
+++ b/rmem_table.h
@@ -36,14 +36,20 @@ struct rmem_table {
     hash_t tag_to_addr;
 };
 
-struct rmem_cp_info {
+enum rmem_txn_type {
+    TXN_CP,
+    TXN_FREE
+};
+
+struct rmem_txn {
     struct list_head list;
+    enum rmem_txn_type type;
     void *src;
     void *dst;
     size_t size;
 };
 
-struct rmem_cp_info_list {
+struct rmem_txn_list {
     struct list_head head;
 };
 
@@ -54,10 +60,12 @@ void *rmem_table_lookup(struct rmem_table *rmem, tag_t tag);
 void free_rmem_table(struct rmem_table *rmem);
 void dump_rmem_table(struct rmem_table *rmem);
 
-void cp_info_list_init(struct rmem_cp_info_list *list);
-void cp_info_list_clear(struct rmem_cp_info_list *list);
-int cp_info_list_add(struct rmem_cp_info_list *list,
+void txn_list_init(struct rmem_txn_list *list);
+void txn_list_clear(struct rmem_txn_list *list);
+int txn_list_add_cp(struct rmem_txn_list *list,
 	void *dst, void *src, size_t size);
-void multi_cp(struct rmem_cp_info_list *list);
+//int txn_list_add_alloc(struct rmem_txn_list *list, size_t size);
+int txn_list_add_free(struct rmem_txn_list *list, void *addr);
+void txn_commit(struct rmem_table *rmem, struct rmem_txn_list *list);
 
 #endif

--- a/rmem_table.h
+++ b/rmem_table.h
@@ -48,7 +48,7 @@ struct rmem_cp_info_list {
 };
 
 void init_rmem_table(struct rmem_table *rmem);
-void *rmem_alloc(struct rmem_table *rmem, size_t size, tag_t tag);
+void *rmem_table_alloc(struct rmem_table *rmem, size_t size, tag_t tag);
 void rmem_table_free(struct rmem_table *rmem, void *ptr);
 void *rmem_table_lookup(struct rmem_table *rmem, tag_t tag);
 void free_rmem_table(struct rmem_table *rmem);

--- a/tests/run_rvm_full.sh
+++ b/tests/run_rvm_full.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 set -e
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-$DIR/rvm_test_full f2 12345 -1
-$DIR/rvm_test_full f2 12345 0
-$DIR/rvm_test_full f2 12345 1
-$DIR/rvm_test_full f2 12345 2
-$DIR/rvm_test_full f2 12345 3
-$DIR/rvm_test_full f2 12345 4
-$DIR/rvm_test_full f2 12345 5
-$DIR/rvm_test_full f2 12345 6
+HOST=$1
+PORT=$2
+
+$DIR/rvm_test_full $HOST $PORT -1
+$DIR/rvm_test_full $HOST $PORT 0
+$DIR/rvm_test_full $HOST $PORT 1
+$DIR/rvm_test_full $HOST $PORT 2
+$DIR/rvm_test_full $HOST $PORT 3
+$DIR/rvm_test_full $HOST $PORT 4
+$DIR/rvm_test_full $HOST $PORT 5
+$DIR/rvm_test_full $HOST $PORT 6


### PR DESCRIPTION
While implementing the micro-benchmarks, I uncovered some bugs.

The primary problem is that frees are not transactional, which leaves the possibility of a double-free. I've changed it so that frees occur transactionally along with copies.

Now the full test and microbenchmarks seem to work properly.
